### PR TITLE
Avoid h being overwritten by residual p

### DIFF
--- a/layers/pna_lspe_layer.py
+++ b/layers/pna_lspe_layer.py
@@ -342,7 +342,7 @@ class PNANoTowersLSPELayer(nn.Module):
         
         if self.residual:
             h = h_in + h  # residual connection
-            h = p_in + p  # residual connection
+            p = p_in + p  # residual connection
         
         return h, p
 


### PR DESCRIPTION
Hi, 

Congratulations for the nice paper&repo! 

I think I found a small typo that could influence the performance of running PNA with residual=True, see attached. 

Best, 
Andreea